### PR TITLE
changed a render to redirect

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -57,7 +57,7 @@ const validateEmailAndPasswordForLogin = [
 
 // Render index
 router.get('/', asyncHandler(async(req, res) => {
-  res.render('index');
+  res.render('user');
 }));
 
 // render register page
@@ -90,7 +90,7 @@ router.post('/register', csrfProtection, validateEmailAndPassword, asyncHandler(
     user.hashedPassword = hashedPassword;
     await user.save();
     loginUser(req, res, user);
-    res.render('user');
+    res.redirect('/users');
   } else {
     const errors = validatorErrors.array().map((error) => error.msg);
     res.render('register', {
@@ -115,7 +115,6 @@ router.post('/login', validateEmailAndPasswordForLogin, csrfProtection, asyncHan
     email,
     password
   } = req.body;
-console.log('1??????????')
   let errors = [];
   const validatorErrors = validationResult(req);
 
@@ -124,7 +123,6 @@ console.log('1??????????')
 
     if (user !== null) {
       const passwordMatch = await bcrypt.compare(password, user.hashedPassword.toString());
-      console.log('2!!!!!!!')
 
       if (passwordMatch) {
         loginUser(req, res, user);


### PR DESCRIPTION
I was walking through the routes wiki and noticed the register page renders the user.pug after login but stays users/login. It should redirect to the users/ page so we keep our routes from overlapping. I changed this and it works as it should.

There is still a similar issue with login where it just renders the user.pug on users/login but should instead redirect to users/. I commented out the res.render and it seems to work with the redirect. Will add this in another commit later